### PR TITLE
Prevent pop-up from rendering outside browser window

### DIFF
--- a/v2/background.js
+++ b/v2/background.js
@@ -20,7 +20,6 @@ const open = (tab, query, frameId, permanent = false) => chrome.tabs.executeScri
     'google-extra': '',
     'domain': 'com'
   }, prefs => {
-    console.log('prefs', prefs);
     chrome.windows.get(tab.windowId, async (win) => {
       if (a[0].position) {
         Object.assign(position, a[0].position);

--- a/v2/background.js
+++ b/v2/background.js
@@ -19,7 +19,7 @@ const open = (tab, query, frameId, permanent = false) => chrome.tabs.executeScri
     'google-extra': '',
     'domain': 'com'
   }, prefs => {
-    chrome.windows.get(tab.windowId, win => {
+    chrome.windows.get(tab.windowId, async (win) => {
       if (a[0].position) {
         Object.assign(position, a[0].position);
       }
@@ -27,6 +27,14 @@ const open = (tab, query, frameId, permanent = false) => chrome.tabs.executeScri
         position.sx = win.left;
         position.sy = win.top;
       }
+
+      // Avoid popup outside the screen
+      const currentWindow = await browser.windows.getCurrent();
+      console.log('currentWindow', currentWindow);
+      const { height, width } = currentWindow;
+      position.sy = Math.min(position.sy, height - prefs.mheight);
+      position.sx = Math.min(position.sx, width - prefs.width);
+
       const url = 'https://translate.google.' + prefs.domain + '/?' +
         (prefs['google-extra'] ? prefs['google-extra'] + '&' : '') +
         'text=' + encodeURIComponent(query);

--- a/v2/background.js
+++ b/v2/background.js
@@ -15,10 +15,12 @@ const open = (tab, query, frameId, permanent = false) => chrome.tabs.executeScri
     'mheight': 600,
     'translate-styles': '',
     'scale': 1.0,
+    'force-inside': true,
     'hide-translator': true,
     'google-extra': '',
     'domain': 'com'
   }, prefs => {
+    console.log('prefs', prefs);
     chrome.windows.get(tab.windowId, async (win) => {
       if (a[0].position) {
         Object.assign(position, a[0].position);
@@ -29,11 +31,12 @@ const open = (tab, query, frameId, permanent = false) => chrome.tabs.executeScri
       }
 
       // Avoid popup outside the screen
-      const currentWindow = await browser.windows.getCurrent();
-      console.log('currentWindow', currentWindow);
-      const { height, width } = currentWindow;
-      position.sy = Math.min(position.sy, height - prefs.mheight);
-      position.sx = Math.min(position.sx, width - prefs.width);
+      if (prefs['force-inside']) {
+        const currentWindow = await browser.windows.getCurrent();
+        const { height, width } = currentWindow;
+        position.sy = Math.min(position.sy, height - prefs.mheight);
+        position.sx = Math.min(position.sx, width - prefs.width);
+      }
 
       const url = 'https://translate.google.' + prefs.domain + '/?' +
         (prefs['google-extra'] ? prefs['google-extra'] + '&' : '') +

--- a/v2/data/options/index.html
+++ b/v2/data/options/index.html
@@ -83,6 +83,10 @@
       <td align="right"><input id="offset-y" type="number"></td>
     </tr>
     <tr>
+      <td><label style="display: inline-block;" for="force-inside">Always render pop-up inside the current window</label><sup>13</sup>:</td>
+      <td align="right"><input id="force-inside" type="checkbox"></td>
+    </tr>
+    <tr>
       <td>Translator's engine:</td>
       <td align="right">
         <select id="domain">
@@ -226,6 +230,7 @@
     <li>When translation page using browser-action click, use this engine for translation.</li>
     <li>If there is a "Definitions of  %s" section, hide the translation section. This is useful to hide the translation section when Google Translator is used for exploring words definition.</li>
     <li>If this option is selected, the extension directly opens the translation window when alt key is hold while double-clicking on a word to select it or when alt key is hold while selecting a sentence.</li>
+    <li>Unchecking this option allows the pop-up to render outside the browser window, useful if you have a big screen and use the browser in window mode.</li>
   </ol>
 
   <script src="index.js"></script>

--- a/v2/data/options/index.js
+++ b/v2/data/options/index.js
@@ -9,6 +9,7 @@ function restore() {
     'scale': 1.0,
     'offset-x': 0,
     'offset-y': 0,
+    'force-inside': true,
     'domain': 'com',
     'use-pointer': true,
     'direct-frame': false,
@@ -27,6 +28,7 @@ function restore() {
     document.getElementById('scale').value = prefs.scale;
     document.getElementById('offset-x').value = prefs['offset-x'];
     document.getElementById('offset-y').value = prefs['offset-y'];
+    document.getElementById('force-inside').checked = prefs['force-inside'];
     document.getElementById('domain').value = prefs.domain;
     document.getElementById('google-page').checked = prefs['google-page'];
     document.getElementById('bing-page').checked = prefs['bing-page'];
@@ -56,6 +58,7 @@ function save() {
     'scale': Math.min(Math.max(parseFloat(document.getElementById('scale').value), 0.5), 1.0),
     'offset-x': Number(document.getElementById('offset-x').value),
     'offset-y': Number(document.getElementById('offset-y').value),
+    'force-inside': document.getElementById('force-inside').checked,
     'domain': document.getElementById('domain').value,
     'use-pointer': document.getElementById('use-pointer').checked,
     'direct-frame': document.getElementById('use-direct').checked,


### PR DESCRIPTION
Fixes #65 

 - Prevents the pop-up from rendering outside the current browser window limits
 - Checks if there's enough vertical and horizontal space to render; if not, renders the pop-up at `window.height - popup.height` and/or `window.width - popup.width`
 - Only works well if the window is fullscreen, because it doesn't check the window position, just height and width
 - Added a new option to the extension settings that sets this feature as default, but allows for disabling it.